### PR TITLE
finish goprotoc cmd

### DIFF
--- a/cmd/goprotoc/codec.go
+++ b/cmd/goprotoc/codec.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/goprotoc/codec.go
+++ b/cmd/goprotoc/codec.go
@@ -146,7 +146,7 @@ func decodeRawMessage(in *codedReader, w io.Writer, indent string, inGroup bool)
 			if isProbablyMessage(v) {
 				fmt.Fprintf(w, "%s%d: <\n", indent, t)
 				nested := newCodedReader(v)
-				if err := decodeRawMessage(nested, w, indent + "  ", false); err != nil {
+				if err := decodeRawMessage(nested, w, indent+"  ", false); err != nil {
 					return err
 				}
 				fmt.Fprintf(w, "%s>\n", indent)
@@ -157,7 +157,7 @@ func decodeRawMessage(in *codedReader, w io.Writer, indent string, inGroup bool)
 			}
 		case proto.WireStartGroup:
 			fmt.Fprintf(w, "%s%d {\n", indent, t)
-			if err := decodeRawMessage(in, w, indent + "  ", true); err != nil {
+			if err := decodeRawMessage(in, w, indent+"  ", true); err != nil {
 				return err
 			}
 			fmt.Fprintf(w, "%s}\n", indent)

--- a/cmd/goprotoc/codec.go
+++ b/cmd/goprotoc/codec.go
@@ -1,1 +1,22 @@
 package main
+
+import (
+	"io"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+func doEncode(encodeType string, fds []*desc.FileDescriptor, r io.Reader) error {
+	// TODO
+	return nil
+}
+
+func doDecode(decodeType string, fds []*desc.FileDescriptor, r io.Reader) error {
+	// TODO
+	return nil
+}
+
+func doDecodeRaw(fds []*desc.FileDescriptor, r io.Reader) error {
+	// TODO
+	return nil
+}

--- a/cmd/goprotoc/codec.go
+++ b/cmd/goprotoc/codec.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"math"
-	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
@@ -171,7 +171,7 @@ func decodeRawMessage(in *codedReader, w io.Writer, indent string, inGroup bool)
 func quoteString(s []byte) string {
 	// strings.Builder returns nil error for all Write* methods,
 	// so we ignore error return values in method calls below
-	var buf strings.Builder
+	var buf bytes.Buffer
 	// use WriteByte here to get any needed indent
 	_ = buf.WriteByte('"')
 	// Loop over the bytes, not the runes.
@@ -205,7 +205,7 @@ func quoteString(s []byte) string {
 func quoteBytes(b []byte) string {
 	// strings.Builder returns nil error for all Write* methods,
 	// so we ignore error return values in method calls below
-	var buf strings.Builder
+	var buf bytes.Buffer
 	// use WriteByte here to get any needed indent
 	_ = buf.WriteByte('"')
 	// Loop over the bytes, not the runes.

--- a/cmd/goprotoc/codec.go
+++ b/cmd/goprotoc/codec.go
@@ -1,22 +1,218 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
+	"math"
+	"strings"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/dynamic"
 )
 
-func doEncode(encodeType string, fds []*desc.FileDescriptor, r io.Reader) error {
-	// TODO
+func doEncode(encodeType string, fds []*desc.FileDescriptor, r io.Reader, w io.Writer) error {
+	var md *desc.MessageDescriptor
+	for _, fd := range fds {
+		md = fd.FindMessage(encodeType)
+		if md != nil {
+			break
+		}
+	}
+	if md == nil {
+		return fmt.Errorf("type not defined: %s", encodeType)
+	}
+
+	var er dynamic.ExtensionRegistry
+	for _, fd := range fds {
+		er.AddExtensionsFromFileRecursively(fd)
+	}
+	dm := dynamic.NewMessageWithExtensionRegistry(md, &er)
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %v", err)
+	}
+	if err := dm.UnmarshalText(b); err != nil {
+		return fmt.Errorf("failed to parse input: %v", err)
+	}
+	b, err = dm.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed to serialize message: %v", err)
+	}
+	_, err = w.Write(b)
+	if err != nil {
+		return fmt.Errorf("failed to write encoded message: %v", err)
+	}
 	return nil
 }
 
-func doDecode(decodeType string, fds []*desc.FileDescriptor, r io.Reader) error {
-	// TODO
+func doDecode(decodeType string, fds []*desc.FileDescriptor, r io.Reader, w io.Writer) error {
+	var md *desc.MessageDescriptor
+	for _, fd := range fds {
+		md = fd.FindMessage(decodeType)
+		if md != nil {
+			break
+		}
+	}
+	if md == nil {
+		return fmt.Errorf("type not defined: %s", decodeType)
+	}
+
+	var er dynamic.ExtensionRegistry
+	for _, fd := range fds {
+		er.AddExtensionsFromFileRecursively(fd)
+	}
+	dm := dynamic.NewMessageWithExtensionRegistry(md, &er)
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %v", err)
+	}
+	if err := dm.Unmarshal(b); err != nil {
+		return fmt.Errorf("failed to parse input: %v", err)
+	}
+	b, err = dm.MarshalTextIndent()
+	if err != nil {
+		return fmt.Errorf("failed to format message: %v", err)
+	}
+	_, err = w.Write(b)
+	if err != nil {
+		return fmt.Errorf("failed to write decoded message: %v", err)
+	}
 	return nil
 }
 
-func doDecodeRaw(fds []*desc.FileDescriptor, r io.Reader) error {
-	// TODO
-	return nil
+func doDecodeRaw(r io.Reader, w io.Writer) error {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	in := newCodedReader(data)
+	return decodeRawMessage(in, w, "", false)
+}
+
+func decodeRawMessage(in *codedReader, w io.Writer, indent string, inGroup bool) error {
+	for {
+		if in.eof() {
+			if inGroup {
+				return io.ErrUnexpectedEOF
+			}
+			return nil
+		}
+		t, wt, err := in.decodeTagAndWireType()
+		if err != nil {
+			return err
+		}
+		if wt == proto.WireEndGroup {
+			if inGroup {
+				return nil
+			}
+			return fmt.Errorf("input contains unexpected 'end group' wire type")
+		}
+		if t < 1 || t > maxTag {
+			return fmt.Errorf("input contains illegal tag number: %d", t)
+		}
+		if t >= specialReservedStart && t <= specialReservedEnd {
+			return fmt.Errorf("input contains illegal tag number: %d", t)
+		}
+		switch wt {
+		case proto.WireVarint:
+			v, err := in.decodeVarint()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%s%d: %d\n", indent, t, v)
+		case proto.WireFixed32:
+			v, err := in.decodeFixed32()
+			if err != nil {
+				return err
+			}
+			f := math.Float32frombits(uint32(v))
+			fmt.Fprintf(w, "%s%d: %f\n", indent, t, f)
+		case proto.WireFixed64:
+			v, err := in.decodeFixed64()
+			if err != nil {
+				return err
+			}
+			f := math.Float64frombits(v)
+			fmt.Fprintf(w, "%s%d: %f\n", indent, t, f)
+		case proto.WireBytes:
+			v, err := in.decodeRawBytes(false)
+			if err != nil {
+				return err
+			}
+			if isProbablyMessage(v) {
+				fmt.Fprintf(w, "%s%d: <\n", indent, t)
+				nested := newCodedReader(v)
+				if err := decodeRawMessage(nested, w, indent + "  ", false); err != nil {
+					return err
+				}
+				fmt.Fprintf(w, "%s>\n", indent)
+			} else if isProbablyString(v) {
+				fmt.Fprintf(w, "%s%d: %s\n", indent, t, quoteString(v))
+			} else {
+				fmt.Fprintf(w, "%s%d: %s\n", indent, t, quoteBytes(v))
+			}
+		case proto.WireStartGroup:
+			fmt.Fprintf(w, "%s%d {\n", indent, t)
+			if err := decodeRawMessage(in, w, indent + "  ", true); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%s}\n", indent)
+		default:
+			// invalid wire type
+			return fmt.Errorf("input contained invalid wire type: %d", wt)
+		}
+	}
+}
+
+func quoteString(s []byte) string {
+	// strings.Builder returns nil error for all Write* methods,
+	// so we ignore error return values in method calls below
+	var buf strings.Builder
+	// use WriteByte here to get any needed indent
+	_ = buf.WriteByte('"')
+	// Loop over the bytes, not the runes.
+	for i := 0; i < len(s); i++ {
+		// Divergence from C++: we don't escape apostrophes.
+		// There's no need to escape them, and the C++ parser
+		// copes with a naked apostrophe.
+		switch c := s[i]; c {
+		case '\n':
+			_, _ = buf.WriteString("\\n")
+		case '\r':
+			_, _ = buf.WriteString("\\r")
+		case '\t':
+			_, _ = buf.WriteString("\\t")
+		case '"':
+			_, _ = buf.WriteString("\\")
+		case '\\':
+			_, _ = buf.WriteString("\\\\")
+		default:
+			if c >= 0x20 && c < 0x7f {
+				_ = buf.WriteByte(c)
+			} else {
+				_, _ = fmt.Fprintf(&buf, "\\%03o", c)
+			}
+		}
+	}
+	_ = buf.WriteByte('"')
+	return buf.String()
+}
+
+func quoteBytes(b []byte) string {
+	// strings.Builder returns nil error for all Write* methods,
+	// so we ignore error return values in method calls below
+	var buf strings.Builder
+	// use WriteByte here to get any needed indent
+	_ = buf.WriteByte('"')
+	// Loop over the bytes, not the runes.
+	for i := 0; i < len(b); i++ {
+		// for bytes, we just hex-encode everything
+		_, _ = fmt.Fprintf(&buf, "\\%03o", b[i])
+	}
+	_ = buf.WriteByte('"')
+	return buf.String()
 }

--- a/cmd/goprotoc/codegen.go
+++ b/cmd/goprotoc/codegen.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/goprotoc/codegen.go
+++ b/cmd/goprotoc/codegen.go
@@ -319,7 +319,7 @@ func applyInsertions(fileName string, contents io.Reader, insertions map[string]
 			}
 		}
 		var sb strings.Builder
-		_, _  = fmt.Fprintf(&sb, "missing insertion point(s) in %q: ", fileName)
+		_, _ = fmt.Fprintf(&sb, "missing insertion point(s) in %q: ", fileName)
 		first := true
 		for lang, points := range pointsByLang {
 			pointSlice := make([]string, 0, len(points))

--- a/cmd/goprotoc/codegen.go
+++ b/cmd/goprotoc/codegen.go
@@ -318,8 +318,8 @@ func applyInsertions(fileName string, contents io.Reader, insertions map[string]
 				points[p] = struct{}{}
 			}
 		}
-		var sb strings.Builder
-		_, _ = fmt.Fprintf(&sb, "missing insertion point(s) in %q: ", fileName)
+		var buf bytes.Buffer
+		_, _ = fmt.Fprintf(&buf, "missing insertion point(s) in %q: ", fileName)
 		first := true
 		for lang, points := range pointsByLang {
 			pointSlice := make([]string, 0, len(points))
@@ -329,12 +329,12 @@ func applyInsertions(fileName string, contents io.Reader, insertions map[string]
 			if first {
 				first = false
 			} else {
-				sb.WriteString("; ")
+				buf.WriteString("; ")
 			}
-			_, _ = fmt.Fprintf(&sb, "%q wants to insert into %s", lang, strings.Join(pointSlice, ","))
+			_, _ = fmt.Fprintf(&buf, "%q wants to insert into %s", lang, strings.Join(pointSlice, ","))
 		}
 
-		return nil, errors.New(sb.String())
+		return nil, errors.New(buf.String())
 	}
 
 	result.Write(data)

--- a/cmd/goprotoc/codegen.go
+++ b/cmd/goprotoc/codegen.go
@@ -1,1 +1,342 @@
 package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/jhump/protoreflect/desc"
+
+	"github.com/jhump/goprotoc/plugins"
+)
+
+var protocVersionStruct = plugins.ProtocVersion{
+	Major:  3,
+	Minor:  5,
+	Patch:  1,
+	Suffix: "go",
+}
+
+var protocOutputs = map[string]struct{}{
+	"cpp":      {},
+	"csharp":   {},
+	"java":     {},
+	"javanano": {},
+	"js":       {},
+	"objc":     {},
+	"php":      {},
+	"python":   {},
+	"ruby":     {},
+}
+
+func doCodeGen(outputs map[string]string, fds []*desc.FileDescriptor, pluginDefs map[string]string) error {
+	req := plugins.CodeGenRequest{
+		Files:         fds,
+		ProtocVersion: protocVersionStruct,
+	}
+	resps := map[string]*plugins.CodeGenResponse{}
+	locations := map[string]string{}
+	for lang, loc := range outputs {
+		resp := plugins.NewCodeGenResponse(lang, nil)
+		resps[lang] = resp
+		locParts := strings.SplitN(loc, ":", 2)
+		var arg string
+		if len(locParts) > 1 {
+			arg = locParts[0]
+			locations[lang] = locParts[1]
+		} else {
+			locations[lang] = loc
+		}
+		pluginName := pluginDefs[lang]
+		if err := executePlugin(&req, resp, pluginName, lang, arg); err != nil {
+			return err
+		}
+	}
+	results := map[string]fileOutput{}
+	for lang, resp := range resps {
+		err := resp.ForEach(func(name, insertionPoint string, data io.Reader) error {
+			loc := locations[lang]
+			fullName, err := filepath.Abs(filepath.Join(loc, name))
+			if err != nil {
+				return err
+			}
+			o := results[fullName]
+			if insertionPoint == "" {
+				if o.createdBy != "" {
+					return fmt.Errorf("conflict: both %s and %s tried to create file %s", o.createdBy, lang, fullName)
+				}
+				o.contents = data
+				o.createdBy = lang
+			} else {
+				if o.insertions == nil {
+					o.insertions = map[string][]insertedContent{}
+					o.insertsFrom = map[string]struct{}{}
+				}
+				content := insertedContent{data: data, lang: lang}
+				o.insertions[insertionPoint] = append(o.insertions[insertionPoint], content)
+				o.insertsFrom[lang] = struct{}{}
+			}
+			results[fullName] = o
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	for fileName, output := range results {
+		if output.contents == nil {
+			return fmt.Errorf("%q generated invalid content for %s", output.createdBy, fileName)
+		}
+		fileContents := output.contents
+		if len(output.insertions) > 0 {
+			var err error
+			fileContents, err = applyInsertions(fileName, output.contents, output.insertions)
+			if err != nil {
+				return err
+			}
+		}
+		w, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(w, fileContents)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type fileOutput struct {
+	contents    io.Reader
+	createdBy   string
+	insertions  map[string][]insertedContent
+	insertsFrom map[string]struct{}
+}
+
+func executePlugin(req *plugins.CodeGenRequest, resp *plugins.CodeGenResponse, pluginName, lang, outputArg string) error {
+	req.Args = strings.Split(outputArg, ",")
+	if pluginName == "" {
+		if _, ok := protocOutputs[lang]; ok {
+			return driveProtocAsPlugin(req, resp, lang)
+		}
+		pluginName = "protoc-gen-" + lang
+	}
+	return plugins.Exec(context.Background(), pluginName, req, resp)
+}
+
+func driveProtocAsPlugin(req *plugins.CodeGenRequest, resp *plugins.CodeGenResponse, lang string) (err error) {
+	for _, arg := range req.Args {
+		if strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("option %q for %s output does not start with '-'", arg, lang)
+		}
+	}
+
+	tmpDir, err := ioutil.TempDir("", "go-protoc")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		cleanupErr := os.RemoveAll(tmpDir)
+		if err == nil {
+			err = cleanupErr
+		}
+	}()
+
+	outDir := filepath.Join(tmpDir, "output")
+	if err := os.Mkdir(outDir, 0777); err != nil {
+		return err
+	}
+
+	fds := desc.ToFileDescriptorSet(req.Files...)
+	descFile := filepath.Join(tmpDir, "descriptors")
+	if fdsBytes, err := proto.Marshal(fds); err != nil {
+		return err
+	} else if err := ioutil.WriteFile(descFile, fdsBytes, 0666); err != nil {
+		return err
+	}
+
+	args := make([]string, 2+len(req.Files)+len(req.Args))
+	args[0] = "--descriptor_set_in=" + descFile
+	args[1] = "--" + lang + "_out=" + outDir
+	for i, arg := range req.Args {
+		args[i+2] = arg
+	}
+	for i, f := range req.Files {
+		args[i+2+len(req.Args)] = f.GetName()
+	}
+
+	cmd := exec.Command("protoc", args...)
+	var combinedOutput bytes.Buffer
+	cmd.Stdout = &combinedOutput
+	cmd.Stderr = &combinedOutput
+	if err := cmd.Run(); err != nil {
+		if err, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("protoc failed to produce output for %s: %v\n%s", lang, err, combinedOutput.String())
+		}
+		return err
+	}
+
+	return filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if (info.Mode() & os.ModeType) != 0 {
+			// not a regular file
+			return nil
+		}
+		relPath, err := filepath.Rel(outDir, path)
+		if err != nil {
+			return err
+		}
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		out := resp.OutputFile(relPath)
+		_, err = io.Copy(out, in)
+		return err
+	})
+}
+
+var insertionPointMarker = []byte("@@protoc_insertion_point(")
+
+type insertedContent struct {
+	data io.Reader
+	lang string
+}
+
+func applyInsertions(fileName string, contents io.Reader, insertions map[string][]insertedContent) (io.Reader, error) {
+	var result bytes.Buffer
+
+	var data []byte
+	type toBytes interface {
+		Bytes() []byte
+	}
+	if b, ok := contents.(toBytes); ok {
+		data = b.Bytes()
+	} else {
+		var err error
+		data, err = ioutil.ReadAll(contents)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for {
+		pos := bytes.Index(data, insertionPointMarker)
+		if pos < 0 {
+			break
+		}
+		startPos := pos + len(insertionPointMarker)
+		endPos := bytes.IndexByte(data[startPos:], ')')
+		if endPos < 0 {
+			// malformed marker! skip it
+			break
+		}
+		point := string(data[startPos:endPos])
+		insertedData := insertions[point]
+		if len(insertedData) == 0 {
+			result.Write(data[:endPos+1])
+			data = data[endPos+1:]
+			continue
+		}
+
+		delete(insertions, point)
+
+		prevLine := bytes.LastIndexByte(data[:pos], '\n')
+		prevComment := bytes.LastIndexByte(data[prevLine+1:pos], '/')
+		var insertionIndex int
+		var sep, indent []byte
+		if prevComment != -1 &&
+			data[prevLine+1+prevComment+1] == '*' &&
+			len(bytes.TrimSpace(data[prevLine+1+prevComment+2:pos])) == 0 {
+			// insertion point preceded by "/* ", so we insert directly before
+			// that with no indentation
+			insertionIndex = prevLine + 1 + prevComment
+			sep = []byte{' '}
+		} else {
+			// otherwise, insert before the insertion point line, using same
+			// indent as observed on insertion point line
+			insertionIndex = prevLine + 1
+			sep = []byte{'\n'}
+			line := data[insertionIndex:pos]
+			trimmedLine := bytes.TrimLeftFunc(line, unicode.IsSpace)
+			if len(line) > len(trimmedLine) {
+				indent = line[:len(line)-len(trimmedLine)]
+			}
+		}
+
+		result.Write(data[:insertionIndex])
+		for _, ins := range insertedData {
+			if len(indent) == 0 {
+				if _, err := io.Copy(&result, ins.data); err != nil {
+					return nil, err
+				}
+			} else {
+				// if there's an indent, break up the inserted data
+				// into lines and prefix each line with the indent
+				insData, err := ioutil.ReadAll(ins.data)
+				if err != nil {
+					return nil, err
+				}
+				lines := bytes.Split(insData, []byte{'\n'})
+				for _, line := range lines {
+					result.Write(indent)
+					result.Write(line)
+				}
+			}
+
+			if !bytes.HasSuffix(result.Bytes(), sep) {
+				result.Write(sep)
+			}
+		}
+		result.Write(data[insertionIndex : endPos+1])
+		data = data[endPos+1:]
+	}
+
+	if len(insertions) > 0 {
+		// gather missing insertion points by lang/plugin
+		pointsByLang := map[string]map[string]struct{}{}
+		for p, data := range insertions {
+			for _, insertion := range data {
+				points := pointsByLang[insertion.lang]
+				if points == nil {
+					points = map[string]struct{}{}
+					pointsByLang[insertion.lang] = points
+				}
+				points[p] = struct{}{}
+			}
+		}
+		var sb strings.Builder
+		_, _  = fmt.Fprintf(&sb, "missing insertion point(s) in %q: ", fileName)
+		first := true
+		for lang, points := range pointsByLang {
+			pointSlice := make([]string, 0, len(points))
+			for p := range points {
+				pointSlice = append(pointSlice, p)
+			}
+			if first {
+				first = false
+			} else {
+				sb.WriteString("; ")
+			}
+			_, _ = fmt.Fprintf(&sb, "%q wants to insert into %s", lang, strings.Join(pointSlice, ","))
+		}
+
+		return nil, errors.New(sb.String())
+	}
+
+	result.Write(data)
+	return &result, nil
+}

--- a/cmd/goprotoc/free_fields.go
+++ b/cmd/goprotoc/free_fields.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/goprotoc/free_fields.go
+++ b/cmd/goprotoc/free_fields.go
@@ -1,12 +1,73 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"sort"
 
 	"github.com/jhump/protoreflect/desc"
 )
 
-func doPrintFreeFieldNumbers(fds []*desc.FileDescriptor, w io.Writer) error {
-	// TODO
-	return nil
+func doPrintFreeFieldNumbers(fds []*desc.FileDescriptor, w io.Writer) {
+	for _, fd := range fds {
+		for _, md := range fd.GetMessageTypes() {
+			printMessageFreeFields(md, w)
+		}
+	}
+}
+
+func printMessageFreeFields(md *desc.MessageDescriptor, w io.Writer) {
+	for _, nested := range md.GetNestedMessageTypes() {
+		printMessageFreeFields(nested, w)
+	}
+
+	unused := computeFreeRanges(md)
+	fmt.Fprintf(w, "%- 35s free:", md.GetFullyQualifiedName())
+	for _, r := range unused {
+		if r.end == maxTag {
+			fmt.Fprintf(w, " %d-INF", r.start)
+		} else if r.start == r.end {
+			fmt.Fprintf(w, " %d", r.start)
+		} else {
+			fmt.Fprintf(w, " %d-%d", r.start, r.end)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+func computeFreeRanges(md *desc.MessageDescriptor) []tagRange {
+	var used []tagRange
+	// compute all used ranges
+	for _, fd := range md.GetFields() {
+		used = append(used, tagRange{start: fd.GetNumber(), end: fd.GetNumber()})
+	}
+	for _, rr := range md.AsDescriptorProto().GetReservedRange() {
+		used = append(used, tagRange{start: rr.GetStart(), end: rr.GetEnd()-1})
+	}
+	for _, extr := range md.GetExtensionRanges() {
+		used = append(used, tagRange{start: extr.Start, end: extr.End})
+	}
+	// sort
+	sort.Slice(used, func(i, j int) bool {
+		return used[i].start < used[j].start
+	})
+	// now compute the inverse (unused ranges)
+	unused := make([]tagRange, 0, len(used)+1)
+	last := int32(0)
+	for _, r := range used {
+		if r.start <= last+1 {
+			last = r.end
+			continue
+		}
+		unused = append(unused, tagRange{start: last+1, end: r.start-1})
+		last = r.end
+	}
+	if last < maxTag {
+		unused = append(unused, tagRange{start: last+1, end: maxTag})
+	}
+	return unused
+}
+
+type tagRange struct {
+	start, end int32
 }

--- a/cmd/goprotoc/free_fields.go
+++ b/cmd/goprotoc/free_fields.go
@@ -42,7 +42,7 @@ func computeFreeRanges(md *desc.MessageDescriptor) []tagRange {
 		used = append(used, tagRange{start: fd.GetNumber(), end: fd.GetNumber()})
 	}
 	for _, rr := range md.AsDescriptorProto().GetReservedRange() {
-		used = append(used, tagRange{start: rr.GetStart(), end: rr.GetEnd()-1})
+		used = append(used, tagRange{start: rr.GetStart(), end: rr.GetEnd() - 1})
 	}
 	for _, extr := range md.GetExtensionRanges() {
 		used = append(used, tagRange{start: extr.Start, end: extr.End})
@@ -59,11 +59,11 @@ func computeFreeRanges(md *desc.MessageDescriptor) []tagRange {
 			last = r.end
 			continue
 		}
-		unused = append(unused, tagRange{start: last+1, end: r.start-1})
+		unused = append(unused, tagRange{start: last + 1, end: r.start - 1})
 		last = r.end
 	}
 	if last < maxTag {
-		unused = append(unused, tagRange{start: last+1, end: maxTag})
+		unused = append(unused, tagRange{start: last + 1, end: maxTag})
 	}
 	return unused
 }

--- a/cmd/goprotoc/free_fields.go
+++ b/cmd/goprotoc/free_fields.go
@@ -1,1 +1,12 @@
 package main
+
+import (
+	"io"
+
+	"github.com/jhump/protoreflect/desc"
+)
+
+func doPrintFreeFieldNumbers(fds []*desc.FileDescriptor, w io.Writer) error {
+	// TODO
+	return nil
+}

--- a/cmd/goprotoc/goprotoc.go
+++ b/cmd/goprotoc/goprotoc.go
@@ -110,7 +110,90 @@ func fail(message string) {
 }
 
 func usage(exitCode int) {
-	// TODO
+	fmt.Printf(
+`Usage: %s [OPTION] PROTO_FILES
+Parse PROTO_FILES and generate output based on the options given:
+  -IPATH, --proto_path=PATH   Specify the directory in which to search for
+                              imports.  May be specified multiple times;
+                              directories will be searched in order.  If not
+                              given, the current working directory is used.
+  --version                   Show version info and exit.
+  -h, --help                  Show this text and exit.
+  --encode=MESSAGE_TYPE       Read a text-format message of the given type
+                              from standard input and write it in binary
+                              to standard output.  The message type must
+                              be defined in PROTO_FILES or their imports.
+  --decode=MESSAGE_TYPE       Read a binary message of the given type from
+                              standard input and write it in text format
+                              to standard output.  The message type must
+                              be defined in PROTO_FILES or their imports.
+  --decode_raw                Read an arbitrary protocol message from
+                              standard input and write the raw tag/value
+                              pairs in text format to standard output.  No
+                              PROTO_FILES should be given when using this
+                              flag.
+  --descriptor_set_in=FILES   Specifies a delimited list of FILES
+                              each containing a FileDescriptorSet (a
+                              protocol buffer defined in descriptor.proto).
+                              The FileDescriptor for each of the PROTO_FILES
+                              provided will be loaded from these
+                              FileDescriptorSets. If a FileDescriptor
+                              appears multiple times, the first occurrence
+                              will be used.
+  -oFILE,                     Writes a FileDescriptorSet (a protocol buffer,
+    --descriptor_set_out=FILE defined in descriptor.proto) containing all of
+                              the input files to FILE.
+  --include_imports           When using --descriptor_set_out, also include
+                              all dependencies of the input files in the
+                              set, so that the set is self-contained.
+  --include_source_info       When using --descriptor_set_out, do not strip
+                              SourceCodeInfo from the FileDescriptorProto.
+                              This results in vastly larger descriptors that
+                              include information about the original
+                              location of each decl in the source file as
+                              well as surrounding comments.
+  --print_free_field_numbers  Print the free field numbers of the messages
+                              defined in the given proto files. Groups share
+                              the same field number space with the parent
+                              message. Extension ranges are counted as
+                              occupied fields numbers.
+  --plugin=EXECUTABLE         Specifies a plugin executable to use.
+                              Normally, protoc searches the PATH for
+                              plugins, but you may specify additional
+                              executables not in the path using this flag.
+                              Additionally, EXECUTABLE may be of the form
+                              NAME=PATH, in which case the given plugin name
+                              is mapped to the given executable even if
+                              the executable's own name differs.
+  --<PLUGIN>_out=OUT_DIR      Invokes the plugin named <PLUGIN>, instructing
+                              it to generate source code into the given
+                              OUT_DIR. The given OUT_DIR can be in the
+                              extended form ARGS:OUT_DIR, in which case ARGS
+                              are extra arguments/flags to pass to the
+                              plugin.
+                              The plugin binary is located by searching for
+                              for any plugin locations configured with
+                              --plugin flags. If no such flags were provided
+                              for the named plugin, then an executable named
+                              'protoc-gen-<PLUGIN>' is used.
+                              If the named plugin is 'cpp', 'csharp', 'java',
+                              'javanano', 'js', 'objc', 'php', 'python', or
+                              'ruby' then the protoc binary is used to
+                              generate the output code (instead of some
+                              plugin).
+  @<filename>                 Read options and filenames from file. If a
+                              relative file path is specified, the file
+                              will be searched in the working directory.
+                              The --proto_path option will not affect how
+                              this argument file is searched. Content of
+                              the file will be expanded in the position of
+                              @<filename> as in the argument list. Note
+                              that shell expansion is not applied to the
+                              content of the file (i.e., you cannot use
+                              quotes, wildcards, escapes, commands, etc.).
+                              Each line corresponds to a single argument,
+                              even if it contains spaces.
+`, os.Args[0])
 	os.Exit(exitCode)
 }
 

--- a/cmd/goprotoc/goprotoc.go
+++ b/cmd/goprotoc/goprotoc.go
@@ -11,13 +11,19 @@
 // generation logic: it can only execute plugins to generate code. In order
 // to generate code that is built into the standard protoc (such as Python,
 // C++, Java, etc), this program can shell out to the standard protoc,
-// driving it as if it were a plugin.
+// driving it as if it were a plugin. In this mode, it provides to protoc
+// the file descriptors it has already parsed, instead of asking protoc to
+// re-parse all of the source code.
 package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
 )
@@ -28,8 +34,7 @@ var gitSha = "" // can be replaced by -X linker flag
 
 func main() {
 	var opts protocOptions
-	err := parseFlags("", os.Args[1:], &opts, map[string]struct{}{})
-	if err != nil {
+	if err := parseFlags("", os.Args[1:], &opts, map[string]struct{}{}); err != nil {
 		fail(err.Error())
 	}
 
@@ -37,47 +42,62 @@ func main() {
 		fail("Only one of --descriptor_set_in and --proto_path can be specified.")
 	}
 
+	if len(opts.protoFiles) == 0 && !opts.decodeRaw {
+		fail("Missing input file.")
+	} else if len(opts.protoFiles) > 0 && opts.decodeRaw {
+		fail("When using --decode_raw, no input files should be given.")
+	}
+
 	var fds []*desc.FileDescriptor
-	if len(opts.inputDescriptors) > 0 {
-		var err error
-		if fds, err = loadDescriptors(opts.inputDescriptors); err != nil {
-			fail(err.Error())
-		}
-	} else {
-		p := protoparse.Parser{
-			ImportPaths:           opts.includePaths,
-			IncludeSourceCodeInfo: opts.includeSourceInfo,
-		}
-		var err error
-		if fds, err = p.ParseFiles(opts.protoFiles...); err != nil {
-			fail(err.Error())
+	if len(opts.protoFiles) > 0 {
+		if len(opts.inputDescriptors) > 0 {
+			var err error
+			if fds, err = loadDescriptors(opts.inputDescriptors, opts.protoFiles); err != nil {
+				fail(err.Error())
+			}
+		} else {
+			p := protoparse.Parser{
+				ImportPaths:           opts.includePaths,
+				IncludeSourceCodeInfo: opts.includeSourceInfo,
+			}
+			var err error
+			if fds, err = p.ParseFiles(opts.protoFiles...); err != nil {
+				fail(err.Error())
+			}
 		}
 	}
 
-	if len(opts.output) > 0 && opts.encodeType != "" {
+	doingCodeGen := len(opts.output) > 0 || opts.outputDescriptor != ""
+	if doingCodeGen && opts.encodeType != "" {
 		fail("Cannot use --encode and generate code or descriptors at the same time.")
 	}
-	if len(opts.output) > 0 && (opts.decodeType != "" || opts.decodeRaw) {
+	if doingCodeGen && (opts.decodeType != "" || opts.decodeRaw) {
 		fail("Cannot use --decode and generate code or descriptors at the same time.")
 	}
 	if opts.encodeType != "" && (opts.decodeType != "" || opts.decodeRaw) {
 		fail("Only one of --encode and --decode can be specified.")
 	}
 
+	var err error
 	switch {
 	case opts.encodeType != "":
-		err = doEncode(opts.encodeType, fds, os.Stdin)
+		err = doEncode(opts.encodeType, fds, os.Stdin, os.Stdout)
 	case opts.decodeType != "":
-		err = doDecode(opts.decodeType, fds, os.Stdin)
+		err = doDecode(opts.decodeType, fds, os.Stdin, os.Stdout)
 	case opts.decodeRaw:
-		err = doDecodeRaw(fds, os.Stdin)
+		err = doDecodeRaw(os.Stdin, os.Stdout)
 	case opts.printFreeFieldNumbers:
-		err = doPrintFreeFieldNumbers(fds, os.Stdout)
+		doPrintFreeFieldNumbers(fds, os.Stdout)
 	default:
-		if len(opts.output) == 0 {
+		if !doingCodeGen {
 			fail("Missing output directives.")
 		}
-		err = doCodeGen(opts.output, fds, opts.pluginDefs)
+		if len(opts.output) > 0 {
+			err = doCodeGen(opts.output, fds, opts.pluginDefs)
+		}
+		if err == nil && opts.outputDescriptor != "" {
+			err = saveDescriptor(opts.outputDescriptor, fds, opts.includeImports, opts.includeSourceInfo)
+		}
 	}
 	if err != nil {
 		fail(err.Error())
@@ -94,7 +114,103 @@ func usage(exitCode int) {
 	os.Exit(exitCode)
 }
 
-func loadDescriptors(fileNames []string) ([]*desc.FileDescriptor, error) {
-	// TODO
-	return nil,  nil
+func loadDescriptors(descFileNames []string, inputProtoFiles []string) ([]*desc.FileDescriptor, error) {
+	allFiles := map[string]*descriptor.FileDescriptorProto{}
+	for _, fileName := range descFileNames {
+		d, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			return nil, err
+		}
+		var set descriptor.FileDescriptorSet
+		if err := proto.Unmarshal(d, &set); err != nil {
+			return nil, fmt.Errorf("file %q is not a valid file descriptor set: %v", fileName, err)
+		}
+		for _, fd := range set.File {
+			if _, ok := allFiles[fd.GetName()]; !ok {
+				// only load into allFiles map if not already present: we keep
+				// only the first file found for a given name
+				allFiles[fd.GetName()] = fd
+			}
+		}
+	}
+	result := make([]*desc.FileDescriptor, len(inputProtoFiles))
+	linked := map[string]*desc.FileDescriptor{}
+	for i, protoName := range inputProtoFiles {
+		if _, ok := allFiles[protoName]; !ok {
+			return nil, fmt.Errorf("file not found: %q", protoName)
+		}
+		var err error
+		result[i], err = linkFile(protoName, allFiles, linked, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not load %q: %v", protoName, err)
+		}
+	}
+	return result, nil
+}
+
+func linkFile(fileName string, fds map[string]*descriptor.FileDescriptorProto, linkedFds map[string]*desc.FileDescriptor, seen []string) (*desc.FileDescriptor, error) {
+	for _, name := range seen {
+		if fileName == name {
+			seen = append(seen, fileName)
+			return nil, fmt.Errorf("cyclic imports: %v", strings.Join(seen, " -> "))
+		}
+	}
+	seen = append(seen, fileName)
+	fd, ok := linkedFds[fileName]
+	if ok {
+		return fd, nil
+	}
+	fdUnlinked, ok := fds[fileName]
+	if !ok {
+		return nil, fmt.Errorf("could not find dependency %q", fileName)
+	}
+	deps := make([]*desc.FileDescriptor, len(fdUnlinked.Dependency))
+	for i, dep := range fdUnlinked.Dependency {
+		var err error
+		deps[i], err = linkFile(dep, fds, linkedFds, seen)
+		if err != nil {
+			return nil, err
+		}
+	}
+	fd, err := desc.CreateFileDescriptor(fdUnlinked, deps...)
+	if err == nil {
+		linkedFds[fileName] = fd
+	}
+	return fd, err
+}
+
+func saveDescriptor(dest string, fds []*desc.FileDescriptor, includeImports, includeSourceInfo bool) error {
+	fdsByName := map[string]*descriptor.FileDescriptorProto{}
+	var fdSet descriptor.FileDescriptorSet
+	for _, fd := range fds {
+		toFileDescriptorSet(fdsByName, &fdSet, fd, includeImports, includeSourceInfo)
+	}
+	if b, err := proto.Marshal(&fdSet); err != nil {
+		return err
+	} else {
+		return ioutil.WriteFile(dest, b, 0666)
+	}
+}
+
+func toFileDescriptorSet(resultMap map[string]*descriptor.FileDescriptorProto, fdSet *descriptor.FileDescriptorSet, fd *desc.FileDescriptor, includeImports, includeSourceInfo bool) {
+	if _, ok := resultMap[fd.GetName()]; ok {
+		// already done this one
+		return
+	}
+
+	if includeImports {
+		for _, dep := range fd.GetDependencies() {
+			toFileDescriptorSet(resultMap, fdSet, dep, includeImports, includeSourceInfo)
+		}
+	}
+	fdp := fd.AsFileDescriptorProto()
+	if !includeSourceInfo {
+		// NB: this is destructive, so we need to do this step (part of saving
+		// to output descriptor set file) last, *after* descriptors (and any
+		// source code info) have already been used to do code gen
+		fdp.SourceCodeInfo = nil
+	}
+
+	resultMap[fd.GetName()] = fdp
+	fdSet.File = append(fdSet.File, fdp)
 }

--- a/cmd/goprotoc/goprotoc.go
+++ b/cmd/goprotoc/goprotoc.go
@@ -111,7 +111,7 @@ func fail(message string) {
 
 func usage(exitCode int) {
 	fmt.Printf(
-`Usage: %s [OPTION] PROTO_FILES
+		`Usage: %s [OPTION] PROTO_FILES
 Parse PROTO_FILES and generate output based on the options given:
   -IPATH, --proto_path=PATH   Specify the directory in which to search for
                               imports.  May be specified multiple times;

--- a/cmd/goprotoc/goprotoc.go
+++ b/cmd/goprotoc/goprotoc.go
@@ -15,77 +15,34 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
-
-	"github.com/jhump/goprotoc/plugins"
-	"golang.org/x/net/context"
-	"unicode"
 )
 
 const protocVersionEmu = "goprotoc 3.5.1"
 
-var protocVersionStruct = plugins.ProtocVersion{
-	Major:  3,
-	Minor:  5,
-	Patch:  1,
-	Suffix: "go",
-}
-
 var gitSha = "" // can be replaced by -X linker flag
 
-type protocOptions struct {
-	includePaths          []string
-	encodeType            string
-	decodeType            string
-	decodeRaw             bool
-	inputDescriptors      []string
-	outputDescriptor      string
-	includeImports        bool
-	includeSourceInfo     bool
-	printFreeFieldNumbers bool
-	pluginDefs            map[string]string
-	output                map[string]string
-	protoFiles            []string
-}
-
-var protocOutputs = map[string]struct{}{
-	"cpp":      {},
-	"csharp":   {},
-	"java":     {},
-	"javanano": {},
-	"js":       {},
-	"objc":     {},
-	"php":      {},
-	"python":   {},
-	"ruby":     {},
-}
-
 func main() {
-	opts, err := parseFlags("", os.Args[1:], map[string]struct{}{})
+	var opts protocOptions
+	err := parseFlags("", os.Args[1:], &opts, map[string]struct{}{})
 	if err != nil {
 		fail(err.Error())
 	}
 
 	if len(opts.inputDescriptors) > 0 && len(opts.includePaths) > 0 {
-		// TODO: error
-		_ = 0
+		fail("Only one of --descriptor_set_in and --proto_path can be specified.")
 	}
 
 	var fds []*desc.FileDescriptor
 	if len(opts.inputDescriptors) > 0 {
-		// TODO
-		_ = 0
+		var err error
+		if fds, err = loadDescriptors(opts.inputDescriptors); err != nil {
+			fail(err.Error())
+		}
 	} else {
 		p := protoparse.Parser{
 			ImportPaths:           opts.includePaths,
@@ -107,241 +64,28 @@ func main() {
 		fail("Only one of --encode and --decode can be specified.")
 	}
 
-	if opts.encodeType != "" {
-		// TODO: do encoding
-		_ = 0
+	switch {
+	case opts.encodeType != "":
+		err = doEncode(opts.encodeType, fds, os.Stdin)
+	case opts.decodeType != "":
+		err = doDecode(opts.decodeType, fds, os.Stdin)
+	case opts.decodeRaw:
+		err = doDecodeRaw(fds, os.Stdin)
+	case opts.printFreeFieldNumbers:
+		err = doPrintFreeFieldNumbers(fds, os.Stdout)
+	default:
+		if len(opts.output) == 0 {
+			fail("Missing output directives.")
+		}
+		err = doCodeGen(opts.output, fds, opts.pluginDefs)
 	}
-	if opts.decodeType != "" {
-		// TODO: do decoding
-		_ = 0
+	if err != nil {
+		fail(err.Error())
 	}
-	if opts.decodeRaw {
-		// TODO: do decoding
-		_ = 0
-	}
-	if opts.printFreeFieldNumbers {
-		// TODO: print field numbers
-		_ = 0
-	}
-
-	// TODO: factor this into a function
-	// code gen
-	if len(opts.output) == 0 {
-		fail("Missing output directives.")
-	}
-	req := plugins.CodeGenRequest{
-		Files:         fds,
-		ProtocVersion: protocVersionStruct,
-	}
-	resps := map[string]*plugins.CodeGenResponse{}
-	locations := map[string]string{}
-	for lang, loc := range opts.output {
-		resp := plugins.NewCodeGenResponse(lang, nil)
-		resps[lang] = resp
-		locParts := strings.SplitN(loc, ":", 2)
-		var arg string
-		if len(locParts) > 1 {
-			arg = locParts[0]
-			locations[lang] = locParts[1]
-		} else {
-			locations[lang] = loc
-		}
-		if err := executePlugin(&req, resp, opts, lang, arg); err != nil {
-			fail(err.Error())
-		}
-	}
-	results := map[string]fileOutput{}
-	for lang, resp := range resps {
-		err := resp.ForEach(func(name, insertionPoint string, data io.Reader) error {
-			loc := locations[lang]
-			fullName, err := filepath.Abs(filepath.Join(loc, name))
-			if err != nil {
-				return err
-			}
-			o := results[fullName]
-			if insertionPoint == "" {
-				if o.createdBy != "" {
-					// TODO: error
-					_ = 0
-				}
-				o.contents = data
-				o.createdBy = lang
-			} else {
-				if o.insertions == nil {
-					o.insertions = map[string][]insertedContent{}
-					o.insertsFrom = map[string]struct{}{}
-				}
-				content := insertedContent{data: data, lang: lang}
-				o.insertions[insertionPoint] = append(o.insertions[insertionPoint], content)
-				o.insertsFrom[lang] = struct{}{}
-			}
-			results[fullName] = o
-			return nil
-		})
-		if err != nil {
-			fail(err.Error())
-		}
-	}
-
-	for fileName, output := range results {
-		if output.contents == nil {
-			// TODO: fail
-			_ = 0
-		}
-		fileContents := output.contents
-		if len(output.insertions) > 0 {
-			fileContents, err = applyInsertions(output.contents, output.insertions)
-			if err != nil {
-				fail(err.Error())
-			}
-		}
-		w, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
-		if err != nil {
-			// TODO: fail
-			_ = 0
-		}
-		_, err = io.Copy(w, fileContents)
-		if err != nil {
-			// TODO: fail
-			_ = 0
-		}
-	}
-}
-
-type fileOutput struct {
-	contents    io.Reader
-	createdBy   string
-	insertions  map[string][]insertedContent
-	insertsFrom map[string]struct{}
-}
-
-func parseFlags(source string, args []string, sourcesSeen map[string]struct{}) (*protocOptions, error) {
-	var opts protocOptions
-	if _, ok := sourcesSeen[source]; ok {
-		return nil, fmt.Errorf("cycle detected in option files: %s references itself (possibly indirectly)", source)
-	}
-	sourcesSeen[source] = struct{}{}
-
-	for i := 0; i < len(args); i++ {
-		loc := func() string {
-			if source == "" {
-				return ""
-			}
-			return fmt.Sprintf("%s:%d: ", source, i+1)
-		}
-
-		a := args[i]
-		if a == "--" {
-			opts.protoFiles = append(opts.protoFiles, args[i+1:]...)
-			break
-		}
-		if !strings.HasPrefix(a, "-") {
-			opts.protoFiles = append(opts.protoFiles, a)
-			continue
-		}
-		parts := strings.SplitN(args[i], "=", 2)
-
-		getOptionArg := func() string {
-			if len(parts) > 1 {
-				return parts[1]
-			}
-			if len(args) > i+1 {
-				i++
-				return args[i]
-			}
-			fail(fmt.Sprintf("%sMissing value for flag: %s", loc(), parts[0]))
-			return "" // make compiler happy
-		}
-		getBoolArg := func() bool {
-			if len(parts) > 1 {
-				val := strings.ToLower(parts[1])
-				switch val {
-				case "true":
-					return true
-				case "false":
-					return false
-				default:
-					fail(fmt.Sprintf("%svalue for option %s must be 'true' or 'false'", loc(), parts[0]))
-				}
-			}
-			return true
-		}
-		noOptionArg := func() {
-			if len(parts) > 1 {
-				fail(fmt.Sprintf("%s%s does not take a parameter", loc(), parts[0]))
-			}
-		}
-
-		switch parts[0] {
-		case "-I", "--proto_path":
-			opts.includePaths = append(opts.includePaths, getOptionArg())
-		case "--version":
-			noOptionArg()
-			fmt.Printf("%s %s\n", protocVersionEmu, gitSha)
-			os.Exit(0)
-		case "-h", "--help":
-			noOptionArg()
-			usage(0)
-		case "--encode":
-			opts.encodeType = getOptionArg()
-		case "--decode":
-			opts.decodeType = getOptionArg()
-		case "--decode_raw":
-			opts.decodeRaw = getBoolArg()
-		case "--descriptor_set_in":
-			opts.inputDescriptors = append(opts.inputDescriptors, getOptionArg())
-		case "-o", "--descriptor_set_out":
-			opts.outputDescriptor = getOptionArg()
-		case "--include_imports":
-			opts.includeImports = getBoolArg()
-		case "--include_source_info":
-			opts.includeSourceInfo = getBoolArg()
-		case "--print_free_field_numbers":
-			opts.printFreeFieldNumbers = getBoolArg()
-		case "--plugin":
-			plDef := strings.SplitN(getOptionArg(), "=", 2)
-			if len(plDef) == 0 {
-				return nil, fmt.Errorf("--plugin argument must not be blank")
-			}
-			var pluginName, pluginLocation string
-			if len(plDef) == 1 {
-				pluginName = filepath.Base(plDef[0])
-				pluginLocation = plDef[0]
-			} else {
-				pluginName = plDef[0]
-				pluginLocation = plDef[1]
-			}
-			if !strings.HasPrefix(pluginName, "protoc-gen-") {
-				return nil, fmt.Errorf("plugin name %s is not valid: name should have 'protoc-gen-' prefix", pluginName)
-			}
-			pluginName = pluginName[len("protoc-gen-"):]
-			opts.pluginDefs[pluginName] = pluginLocation
-		default:
-			switch {
-			case strings.HasPrefix(a, "@"):
-				noOptionArg()
-				source := a[1:]
-				if contents, err := ioutil.ReadFile(source); err != nil {
-					return nil, fmt.Errorf("%scould not load option file %s: %v", loc(), source, err)
-				} else {
-					lines := strings.Split(string(contents), "\n")
-					for i := range lines {
-						lines[i] = strings.TrimSpace(lines[i])
-					}
-					parseFlags(a[1:], lines, sourcesSeen)
-				}
-			case strings.HasPrefix(a, "--") && strings.HasSuffix(a, "_out"):
-				opts.output[a[2:len(a)-4]] = getOptionArg()
-			default:
-				return nil, fmt.Errorf("%sunrecognized option: %s", loc(), parts[0])
-			}
-		}
-	}
-	return &opts, nil
 }
 
 func fail(message string) {
-	fmt.Fprintln(os.Stderr, message)
+	_, _ = fmt.Fprintln(os.Stderr, message)
 	os.Exit(1)
 }
 
@@ -350,193 +94,7 @@ func usage(exitCode int) {
 	os.Exit(exitCode)
 }
 
-func executePlugin(req *plugins.CodeGenRequest, resp *plugins.CodeGenResponse, opts *protocOptions, lang, outputArg string) error {
-	req.Args = strings.Split(outputArg, ",")
-	pluginName := opts.pluginDefs[lang]
-	if pluginName == "" {
-		if _, ok := protocOutputs[lang]; ok {
-			return driveProtocAsPlugin(req, resp, lang)
-		}
-		pluginName = "protoc-gen-" + lang
-	}
-	return plugins.Exec(context.Background(), pluginName, req, resp)
-}
-
-func driveProtocAsPlugin(req *plugins.CodeGenRequest, resp *plugins.CodeGenResponse, lang string) (err error) {
-	for _, arg := range req.Args {
-		if strings.HasPrefix(arg, "-") {
-			return fmt.Errorf("option %q for %s output does not start with '-'", arg, lang)
-		}
-	}
-
-	tmpDir, err := ioutil.TempDir("", "go-protoc")
-	if err != nil {
-		return err
-	}
-	defer func() {
-		cleanupErr := os.RemoveAll(tmpDir)
-		if err == nil {
-			err = cleanupErr
-		}
-	}()
-
-	outDir := filepath.Join(tmpDir, "output")
-	if err := os.Mkdir(outDir, 0777); err != nil {
-		return err
-	}
-
-	fds := desc.ToFileDescriptorSet(req.Files...)
-	descFile := filepath.Join(tmpDir, "descriptors")
-	if fdsBytes, err := proto.Marshal(fds); err != nil {
-		return err
-	} else if err := ioutil.WriteFile(descFile, fdsBytes, 0666); err != nil {
-		return err
-	}
-
-	args := make([]string, 2+len(req.Files)+len(req.Args))
-	args[0] = "--descriptor_set_in=" + descFile
-	args[1] = "--" + lang + "_out=" + outDir
-	for i, arg := range req.Args {
-		args[i+2] = arg
-	}
-	for i, f := range req.Files {
-		args[i+2+len(req.Args)] = f.GetName()
-	}
-
-	cmd := exec.Command("protoc", args...)
-	var combinedOutput bytes.Buffer
-	cmd.Stdout = &combinedOutput
-	cmd.Stderr = &combinedOutput
-	if err := cmd.Run(); err != nil {
-		if err, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("protoc failed to produce output for %s: %v\n%s", lang, err, combinedOutput.String())
-		}
-		return err
-	}
-
-	return filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if (info.Mode() & os.ModeType) != 0 {
-			// not a regular file
-			return nil
-		}
-		relPath, err := filepath.Rel(outDir, path)
-		if err != nil {
-			return err
-		}
-		in, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		out := resp.OutputFile(relPath)
-		_, err = io.Copy(out, in)
-		return err
-	})
-}
-
-var insertionPointMarker = []byte("@@protoc_insertion_point(")
-
-type insertedContent struct {
-	data io.Reader
-	lang string
-}
-
-func applyInsertions(contents io.Reader, insertions map[string][]insertedContent) (io.Reader, error) {
-	var result bytes.Buffer
-
-	var data []byte
-	type toBytes interface {
-		Bytes() []byte
-	}
-	if b, ok := contents.(toBytes); ok {
-		data = b.Bytes()
-	} else {
-		var err error
-		data, err = ioutil.ReadAll(contents)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for {
-		pos := bytes.Index(data, insertionPointMarker)
-		if pos < 0 {
-			break
-		}
-		startPos := pos + len(insertionPointMarker)
-		endPos := bytes.IndexByte(data[startPos:], ')')
-		if endPos < 0 {
-			// malformed marker! skip it
-			break
-		}
-		point := string(data[startPos:endPos])
-		insertedData := insertions[point]
-		if len(insertedData) == 0 {
-			result.Write(data[:endPos+1])
-			data = data[endPos+1:]
-			continue
-		}
-
-		delete(insertions, point)
-
-		prevLine := bytes.LastIndexByte(data[:pos], '\n')
-		prevComment := bytes.LastIndexByte(data[prevLine+1:pos], '/')
-		var insertionIndex int
-		var sep, indent []byte
-		if prevComment != -1 &&
-			data[prevLine+1+prevComment+1] == '*' &&
-			len(bytes.TrimSpace(data[prevLine+1+prevComment+2:pos])) == 0 {
-			// insertion point preceded by "/* ", so we insert directly before
-			// that with no indentation
-			insertionIndex = prevLine + 1 + prevComment
-			sep = []byte{' '}
-		} else {
-			// otherwise, insert before the insertion point line, using same
-			// indent as observed on insertion point line
-			insertionIndex = prevLine + 1
-			sep = []byte{'\n'}
-			line := data[insertionIndex:pos]
-			trimmedLine := bytes.TrimLeftFunc(line, unicode.IsSpace)
-			if len(line) > len(trimmedLine) {
-				indent = line[:len(line)-len(trimmedLine)]
-			}
-		}
-
-		result.Write(data[:insertionIndex])
-		for _, ins := range insertedData {
-			if len(indent) == 0 {
-				if _, err := io.Copy(&result, ins.data); err != nil {
-					return nil, err
-				}
-			} else {
-				// if there's an indent, break up the inserted data
-				// into lines and prefix each line with the indent
-				insData, err := ioutil.ReadAll(ins.data)
-				if err != nil {
-					return nil, err
-				}
-				lines := bytes.Split(insData, []byte{'\n'})
-				for _, line := range lines {
-					result.Write(indent)
-					result.Write(line)
-				}
-			}
-
-			if !bytes.HasSuffix(result.Bytes(), sep) {
-				result.Write(sep)
-			}
-		}
-		result.Write(data[insertionIndex : endPos+1])
-		data = data[endPos+1:]
-	}
-
-	if len(insertions) > 0 {
-		// TODO: fail with missing insertion points
-		_ = 0
-	}
-
-	result.Write(data)
-	return &result, nil
+func loadDescriptors(fileNames []string) ([]*desc.FileDescriptor, error) {
+	// TODO
+	return nil,  nil
 }

--- a/cmd/goprotoc/options.go
+++ b/cmd/goprotoc/options.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/goprotoc/options.go
+++ b/cmd/goprotoc/options.go
@@ -1,1 +1,150 @@
 package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type protocOptions struct {
+	includePaths          []string
+	encodeType            string
+	decodeType            string
+	decodeRaw             bool
+	inputDescriptors      []string
+	outputDescriptor      string
+	includeImports        bool
+	includeSourceInfo     bool
+	printFreeFieldNumbers bool
+	pluginDefs            map[string]string
+	output                map[string]string
+	protoFiles            []string
+}
+
+func parseFlags(source string, args []string, opts *protocOptions, sourcesSeen map[string]struct{}) error {
+	if _, ok := sourcesSeen[source]; ok {
+		return fmt.Errorf("cycle detected in option files: %s references itself (possibly indirectly)", source)
+	}
+	sourcesSeen[source] = struct{}{}
+
+	for i := 0; i < len(args); i++ {
+		loc := func() string {
+			if source == "" {
+				return ""
+			}
+			return fmt.Sprintf("%s:%d: ", source, i+1)
+		}
+
+		a := args[i]
+		if a == "--" {
+			opts.protoFiles = append(opts.protoFiles, args[i+1:]...)
+			break
+		}
+		if !strings.HasPrefix(a, "-") {
+			opts.protoFiles = append(opts.protoFiles, a)
+			continue
+		}
+		parts := strings.SplitN(args[i], "=", 2)
+
+		getOptionArg := func() string {
+			if len(parts) > 1 {
+				return parts[1]
+			}
+			if len(args) > i+1 {
+				i++
+				return args[i]
+			}
+			fail(fmt.Sprintf("%sMissing value for flag: %s", loc(), parts[0]))
+			return "" // make compiler happy
+		}
+		getBoolArg := func() bool {
+			if len(parts) > 1 {
+				val := strings.ToLower(parts[1])
+				switch val {
+				case "true":
+					return true
+				case "false":
+					return false
+				default:
+					fail(fmt.Sprintf("%svalue for option %s must be 'true' or 'false'", loc(), parts[0]))
+				}
+			}
+			return true
+		}
+		noOptionArg := func() {
+			if len(parts) > 1 {
+				fail(fmt.Sprintf("%s%s does not take a parameter", loc(), parts[0]))
+			}
+		}
+
+		switch parts[0] {
+		case "-I", "--proto_path":
+			opts.includePaths = append(opts.includePaths, getOptionArg())
+		case "--version":
+			noOptionArg()
+			fmt.Printf("%s %s\n", protocVersionEmu, gitSha)
+			os.Exit(0)
+		case "-h", "--help":
+			noOptionArg()
+			usage(0)
+		case "--encode":
+			opts.encodeType = getOptionArg()
+		case "--decode":
+			opts.decodeType = getOptionArg()
+		case "--decode_raw":
+			opts.decodeRaw = getBoolArg()
+		case "--descriptor_set_in":
+			opts.inputDescriptors = append(opts.inputDescriptors, getOptionArg())
+		case "-o", "--descriptor_set_out":
+			opts.outputDescriptor = getOptionArg()
+		case "--include_imports":
+			opts.includeImports = getBoolArg()
+		case "--include_source_info":
+			opts.includeSourceInfo = getBoolArg()
+		case "--print_free_field_numbers":
+			opts.printFreeFieldNumbers = getBoolArg()
+		case "--plugin":
+			plDef := strings.SplitN(getOptionArg(), "=", 2)
+			if len(plDef) == 0 {
+				return fmt.Errorf("--plugin argument must not be blank")
+			}
+			var pluginName, pluginLocation string
+			if len(plDef) == 1 {
+				pluginName = filepath.Base(plDef[0])
+				pluginLocation = plDef[0]
+			} else {
+				pluginName = plDef[0]
+				pluginLocation = plDef[1]
+			}
+			if !strings.HasPrefix(pluginName, "protoc-gen-") {
+				return fmt.Errorf("plugin name %s is not valid: name should have 'protoc-gen-' prefix", pluginName)
+			}
+			pluginName = pluginName[len("protoc-gen-"):]
+			opts.pluginDefs[pluginName] = pluginLocation
+		default:
+			switch {
+			case strings.HasPrefix(a, "@"):
+				noOptionArg()
+				source := a[1:]
+				if contents, err := ioutil.ReadFile(source); err != nil {
+					return fmt.Errorf("%scould not load option file %s: %v", loc(), source, err)
+				} else {
+					lines := strings.Split(string(contents), "\n")
+					for i := range lines {
+						lines[i] = strings.TrimSpace(lines[i])
+					}
+					if err := parseFlags(a[1:], lines, opts, sourcesSeen); err != nil {
+						return err
+					}
+				}
+			case strings.HasPrefix(a, "--") && strings.HasSuffix(a, "_out"):
+				opts.output[a[2:len(a)-4]] = getOptionArg()
+			default:
+				return fmt.Errorf("%sunrecognized option: %s", loc(), parts[0])
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/goprotoc/reader.go
+++ b/cmd/goprotoc/reader.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"unicode/utf8"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// ErrOverflow is returned when an integer is too large to be represented.
+var ErrOverflow = errors.New("proto: integer overflow")
+
+type codedReader struct {
+	buf   []byte
+	index int
+}
+
+func newCodedReader(buf []byte) *codedReader {
+	return &codedReader{buf: buf}
+}
+
+func (cb *codedReader) eof() bool {
+	return cb.index >= len(cb.buf)
+}
+
+func (cb *codedReader) skip(count int) bool {
+	newIndex := cb.index + count
+	if newIndex > len(cb.buf) {
+		return false
+	}
+	cb.index = newIndex
+	return true
+}
+
+func (cb *codedReader) decodeVarintSlow() (x uint64, err error) {
+	i := cb.index
+	l := len(cb.buf)
+
+	for shift := uint(0); shift < 64; shift += 7 {
+		if i >= l {
+			err = io.ErrUnexpectedEOF
+			return
+		}
+		b := cb.buf[i]
+		i++
+		x |= (uint64(b) & 0x7F) << shift
+		if b < 0x80 {
+			cb.index = i
+			return
+		}
+	}
+
+	// The number is too large to represent in a 64-bit value.
+	err = ErrOverflow
+	return
+}
+
+// DecodeVarint reads a varint-encoded integer from the Buffer.
+// This is the format for the
+// int32, int64, uint32, uint64, bool, and enum
+// protocol buffer types.
+func (cb *codedReader) decodeVarint() (uint64, error) {
+	i := cb.index
+	buf := cb.buf
+
+	if i >= len(buf) {
+		return 0, io.ErrUnexpectedEOF
+	} else if buf[i] < 0x80 {
+		cb.index++
+		return uint64(buf[i]), nil
+	} else if len(buf)-i < 10 {
+		return cb.decodeVarintSlow()
+	}
+
+	var b uint64
+	// we already checked the first byte
+	x := uint64(buf[i]) - 0x80
+	i++
+
+	b = uint64(buf[i])
+	i++
+	x += b << 7
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 7
+
+	b = uint64(buf[i])
+	i++
+	x += b << 14
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 14
+
+	b = uint64(buf[i])
+	i++
+	x += b << 21
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 21
+
+	b = uint64(buf[i])
+	i++
+	x += b << 28
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 28
+
+	b = uint64(buf[i])
+	i++
+	x += b << 35
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 35
+
+	b = uint64(buf[i])
+	i++
+	x += b << 42
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 42
+
+	b = uint64(buf[i])
+	i++
+	x += b << 49
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 49
+
+	b = uint64(buf[i])
+	i++
+	x += b << 56
+	if b&0x80 == 0 {
+		goto done
+	}
+	x -= 0x80 << 56
+
+	b = uint64(buf[i])
+	i++
+	x += b << 63
+	if b&0x80 == 0 {
+		goto done
+	}
+	// x -= 0x80 << 63 // Always zero.
+
+	return 0, ErrOverflow
+
+done:
+	cb.index = i
+	return x, nil
+}
+
+func (cb *codedReader) decodeTagAndWireType() (tag int32, wireType int8, err error) {
+	var v uint64
+	v, err = cb.decodeVarint()
+	if err != nil {
+		return
+	}
+	// low 7 bits is wire type
+	wireType = int8(v & 7)
+	// rest is int32 tag number
+	v = v >> 3
+	if v > math.MaxInt32 {
+		err = fmt.Errorf("tag number out of range: %d", v)
+		return
+	}
+	tag = int32(v)
+	return
+}
+
+// DecodeFixed64 reads a 64-bit integer from the Buffer.
+// This is the format for the
+// fixed64, sfixed64, and double protocol buffer types.
+func (cb *codedReader) decodeFixed64() (x uint64, err error) {
+	// x, err already 0
+	i := cb.index + 8
+	if i < 0 || i > len(cb.buf) {
+		err = io.ErrUnexpectedEOF
+		return
+	}
+	cb.index = i
+
+	x = uint64(cb.buf[i-8])
+	x |= uint64(cb.buf[i-7]) << 8
+	x |= uint64(cb.buf[i-6]) << 16
+	x |= uint64(cb.buf[i-5]) << 24
+	x |= uint64(cb.buf[i-4]) << 32
+	x |= uint64(cb.buf[i-3]) << 40
+	x |= uint64(cb.buf[i-2]) << 48
+	x |= uint64(cb.buf[i-1]) << 56
+	return
+}
+
+// DecodeFixed32 reads a 32-bit integer from the Buffer.
+// This is the format for the
+// fixed32, sfixed32, and float protocol buffer types.
+func (cb *codedReader) decodeFixed32() (x uint64, err error) {
+	// x, err already 0
+	i := cb.index + 4
+	if i < 0 || i > len(cb.buf) {
+		err = io.ErrUnexpectedEOF
+		return
+	}
+	cb.index = i
+
+	x = uint64(cb.buf[i-4])
+	x |= uint64(cb.buf[i-3]) << 8
+	x |= uint64(cb.buf[i-2]) << 16
+	x |= uint64(cb.buf[i-1]) << 24
+	return
+}
+
+// DecodeRawBytes reads a count-delimited byte buffer from the Buffer.
+// This is the format used for the bytes protocol buffer
+// type and for embedded messages.
+func (cb *codedReader) decodeRawBytes(alloc bool) (buf []byte, err error) {
+	n, err := cb.decodeVarint()
+	if err != nil {
+		return nil, err
+	}
+
+	nb := int(n)
+	if nb < 0 {
+		return nil, fmt.Errorf("proto: bad byte length %d", nb)
+	}
+	end := cb.index + nb
+	if end < cb.index || end > len(cb.buf) {
+		return nil, io.ErrUnexpectedEOF
+	}
+
+	if !alloc {
+		buf = cb.buf[cb.index:end]
+		cb.index += nb
+		return
+	}
+
+	buf = make([]byte, nb)
+	copy(buf, cb.buf[cb.index:])
+	cb.index += nb
+	return
+}
+
+const (
+	// MaxTag is the maximum allowed tag number for a field.
+	maxTag = 536870911 // 2^29 - 1
+
+	// SpecialReservedStart is the first tag in a range that is reserved and not
+	// allowed for use in message definitions.
+	specialReservedStart = 19000
+	// SpecialReservedEnd is the last tag in a range that is reserved and not
+	// allowed for use in message definitions.
+	specialReservedEnd = 19999
+)
+
+func isProbablyMessage(data []byte) bool {
+	in := newCodedReader(data)
+	return in.isProbablyMessage(false)
+}
+
+func (cb *codedReader) isProbablyMessage(inGroup bool) bool {
+	for {
+		if cb.eof() {
+			// if in group, we should find "end group" tag before EOF
+			return !inGroup
+		}
+		t, w, err := cb.decodeTagAndWireType()
+		if err != nil {
+			return false
+		}
+		if w == proto.WireEndGroup {
+			return inGroup
+		}
+		if t < 1 || t > maxTag {
+			return false
+		}
+		if t >= specialReservedStart && t <= specialReservedEnd {
+			return false
+		}
+		switch w {
+		case proto.WireVarint:
+			// skip varint by finding last byte (has high bit unset)
+			i := cb.index
+			limit := i + 10 // varint cannot be >10 bytes
+			bs := cb.buf
+			for {
+				if i >= len(bs) || i >= limit {
+					return false
+				}
+				if bs[i]&0x80 == 0 {
+					break
+				}
+				i++
+			}
+			cb.index = i + 1
+		case proto.WireFixed32:
+			if !cb.skip(4) {
+				return false
+			}
+		case proto.WireFixed64:
+			if !cb.skip(8) {
+				return false
+			}
+		case proto.WireBytes:
+			l, err := cb.decodeVarint()
+			if err != nil {
+				return false
+			}
+			if !cb.skip(int(l)) {
+				return false
+			}
+		case proto.WireStartGroup:
+			if !cb.isProbablyMessage(true) {
+				return false
+			}
+		default:
+			// invalid wire type
+			return false
+		}
+	}
+}
+
+func isProbablyString(data []byte) bool {
+	for len(data) > 0 {
+		r, n := utf8.DecodeRune(data)
+		if r == utf8.RuneError {
+			return false
+		}
+		data = data[n:]
+	}
+	return true
+}

--- a/plugins/doc.go
+++ b/plugins/doc.go
@@ -4,8 +4,8 @@
 //
 // Interface for Protoc Plugins
 //
-// A simple protoc plugin can simply provide a function whose signature
-// matches the Plugin type and then wire it up in a main method like so:
+// A protoc plugin need only provide a function whose signature matches the
+// Plugin type and then wire it up in a main method like so:
 //
 //    func main() {
 //        output := os.Stdout

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -79,6 +79,9 @@ func (resp *CodeGenResponse) OutputFile(name string) io.Writer {
 	return resp.OutputSnippet(name, "")
 }
 
+// ForEach invokes the given function for each output in the response so far.
+// The given reader provides access to examine the file/snippet contents. If the
+// function returns an error, ForEach stops iteration and returns that error.
 func (resp *CodeGenResponse) ForEach(fn func(name, insertionPoint string, data io.Reader) error) error {
 	resp.output.mu.Lock()
 	defer resp.output.mu.Unlock()


### PR DESCRIPTION
This fleshes out the implementation of the `goprotoc` command, including addressing all TODOs as well as re-arranging the code substantially (to break up the code into smaller, easier to read files).