### PR TITLE
Handle empty output arguments for plugins

### DIFF
--- a/cmd/goprotoc/codegen.go
+++ b/cmd/goprotoc/codegen.go
@@ -154,7 +154,9 @@ type fileOutput struct {
 }
 
 func executePlugin(req *plugins.CodeGenRequest, resp *plugins.CodeGenResponse, pluginName, lang, outputArg string) error {
-	req.Args = strings.Split(outputArg, ",")
+	if len(outputArg) > 0 {
+		req.Args = strings.Split(outputArg, ",")
+	}
 	if pluginName == "" {
 		if _, ok := protocOutputs[lang]; ok {
 			return driveProtocAsPlugin(req, resp, lang)


### PR DESCRIPTION
Yesterday, I thought the bug with `req.Args` was external to goprotoc, but it turns it that it is because we are splitting an empty string.

https://golang.org/pkg/strings/#Split

> If s does not contain sep and sep is not empty, Split returns a slice of length 1 whose only element is s.

`sep` is `","`, and `s` is `""`, so `strings.Split("" ",")` returns `[]string{""}`.

The default value for `outputArg` is an empty string anyways, ie `--go_out=OUTPUT_ARG:/path`  vs `--go_out=/path`.