### PR TITLE
Turn off compression for zip and jar files

### DIFF
--- a/app/goprotoc/codegen.go
+++ b/app/goprotoc/codegen.go
@@ -284,7 +284,10 @@ func writeArchiveResult(fileName string, includeManifest bool, files map[string]
 	}()
 
 	if includeManifest {
-		mw, err := z.Create("META-INF/MANIFEST.MF")
+		mw, err := z.CreateHeader(&zip.FileHeader{
+			Name:   "META-INF/MANIFEST.MF",
+			Method: zip.Store,
+		})
 		if err != nil {
 			return err
 		}
@@ -294,7 +297,10 @@ func writeArchiveResult(fileName string, includeManifest bool, files map[string]
 	}
 
 	for name, data := range files {
-		w, err := z.Create(name)
+		w, err := z.CreateHeader(&zip.FileHeader{
+			Name:   name,
+			Method: zip.Store,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
After applying #15:

```
$ function zipdiff() { diff -W200 -y <(unzip -vql $1 | sort -k8) <(unzip -vql $2 | sort -k8); }

$ zipdiff gen/goprotoc/python/google/ads/googleads/v1/common/common.zip gen/protoc/python/google/ads/googleads/v1/common/common.zip
  705259            82822  88%                            27 files				   |	  673014           673014   0%                            27 files
--------          -------  ---                            -------					--------          -------  ---                            -------
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name						 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----						--------  ------  ------- ---- ---------- ----- --------  ----
    8674  Defl:N     1651  81% 00-00-1980 00:00 691f9e61  google/ads/googleads/v1/common/ad_asse   |	    8501  Stored     8501   0% 01-01-1980 00:00 dd46fa32  google/ads/googleads/v1/common/ad_asse
  104566  Defl:N     9100  91% 00-00-1980 00:00 63a1ab6f  google/ads/googleads/v1/common/ad_type   |	   99538  Stored    99538   0% 01-01-1980 00:00 47de1748  google/ads/googleads/v1/common/ad_type
   12439  Defl:N     2034  84% 00-00-1980 00:00 a9c7ead8  google/ads/googleads/v1/common/asset_t   |	   12082  Stored    12082   0% 01-01-1980 00:00 f3317fb6  google/ads/googleads/v1/common/asset_t
   33791  Defl:N     3642  89% 00-00-1980 00:00 36da3a17  google/ads/googleads/v1/common/bidding   |	   32290  Stored    32290   0% 01-01-1980 00:00 e15fc3d4  google/ads/googleads/v1/common/bidding
    5764  Defl:N     1353  77% 00-00-1980 00:00 35087162  google/ads/googleads/v1/common/click_l   |	    5583  Stored     5583   0% 01-01-1980 00:00 e37291fd  google/ads/googleads/v1/common/click_l
  124139  Defl:N    11802  91% 00-00-1980 00:00 7519e5e0  google/ads/googleads/v1/common/criteri   |	  120186  Stored   120186   0% 01-01-1980 00:00 c90d5746  google/ads/googleads/v1/common/criteri
   13801  Defl:N     2111  85% 00-00-1980 00:00 55e3eee0  google/ads/googleads/v1/common/criteri   |	   13309  Stored    13309   0% 01-01-1980 00:00 acc5ba46  google/ads/googleads/v1/common/criteri
    3948  Defl:N     1203  70% 00-00-1980 00:00 f1fe3921  google/ads/googleads/v1/common/custom_   |	    3891  Stored     3891   0% 01-01-1980 00:00 564e4ac4  google/ads/googleads/v1/common/custom_
    3847  Defl:N     1198  69% 00-00-1980 00:00 ae386051  google/ads/googleads/v1/common/dates_p   |	    3769  Stored     3769   0% 01-01-1980 00:00 63c6c91d  google/ads/googleads/v1/common/dates_p
    3614  Defl:N     1186  67% 00-00-1980 00:00 41516287  google/ads/googleads/v1/common/explore   |	    3582  Stored     3582   0% 01-01-1980 00:00 6935e778  google/ads/googleads/v1/common/explore
   65387  Defl:N     5805  91% 00-00-1980 00:00 b6447111  google/ads/googleads/v1/common/extensi   |	   62068  Stored    62068   0% 01-01-1980 00:00 aee20a8f  google/ads/googleads/v1/common/extensi
    3888  Defl:N     1242  68% 00-00-1980 00:00 9055aca4  google/ads/googleads/v1/common/feed_co   |	    3792  Stored     3792   0% 01-01-1980 00:00 5e776be2  google/ads/googleads/v1/common/feed_co
    4366  Defl:N     1353  69% 00-00-1980 00:00 5e9e5f70  google/ads/googleads/v1/common/final_a   |	    4310  Stored     4310   0% 01-01-1980 00:00 4e2bbb2a  google/ads/googleads/v1/common/final_a
    8523  Defl:N     1733  80% 00-00-1980 00:00 9610e854  google/ads/googleads/v1/common/frequen   |	    8326  Stored     8326   0% 01-01-1980 00:00 ecf16ca4  google/ads/googleads/v1/common/frequen
    4795  Defl:N     1398  71% 00-00-1980 00:00 117a4769  google/ads/googleads/v1/common/keyword   |	    4696  Stored     4696   0% 01-01-1980 00:00 834d85ca  google/ads/googleads/v1/common/keyword
   21461  Defl:N     2846  87% 00-00-1980 00:00 fb7e0551  google/ads/googleads/v1/common/matchin   |	   20680  Stored    20680   0% 01-01-1980 00:00 d3f0ba8f  google/ads/googleads/v1/common/matchin
   80071  Defl:N     7269  91% 00-00-1980 00:00 7fce3c4c  google/ads/googleads/v1/common/metrics   |	   72947  Stored    72947   0% 01-01-1980 00:00 18a80300  google/ads/googleads/v1/common/metrics
   39769  Defl:N     4314  89% 00-00-1980 00:00 92ca302c  google/ads/googleads/v1/common/policy_   |	   38304  Stored    38304   0% 01-01-1980 00:00 78c1722b  google/ads/googleads/v1/common/policy_
    3503  Defl:N     1172  67% 00-00-1980 00:00 4e74d2dc  google/ads/googleads/v1/common/real_ti   |	    3471  Stored     3471   0% 01-01-1980 00:00 5792ee1b  google/ads/googleads/v1/common/real_ti
   59412  Defl:N     6159  90% 00-00-1980 00:00 1664831d  google/ads/googleads/v1/common/segment   |	   55592  Stored    55592   0% 01-01-1980 00:00 6697a543  google/ads/googleads/v1/common/segment
   23746  Defl:N     2322  90% 00-00-1980 00:00 20ece356  google/ads/googleads/v1/common/simulat   |	   22648  Stored    22648   0% 01-01-1980 00:00 c2d38290  google/ads/googleads/v1/common/simulat
    5984  Defl:N     1514  75% 00-00-1980 00:00 b04a0828  google/ads/googleads/v1/common/tag_sni   |	    5834  Stored     5834   0% 01-01-1980 00:00 988ead38  google/ads/googleads/v1/common/tag_sni
    6034  Defl:N     1492  75% 00-00-1980 00:00 527ad26e  google/ads/googleads/v1/common/targeti   |	    5885  Stored     5885   0% 01-01-1980 00:00 00612e68  google/ads/googleads/v1/common/targeti
    3960  Defl:N     1229  69% 00-00-1980 00:00 0b2f2e2a  google/ads/googleads/v1/common/text_la   |	    3854  Stored     3854   0% 01-01-1980 00:00 22727024  google/ads/googleads/v1/common/text_la
    5344  Defl:N     1348  75% 00-00-1980 00:00 437652db  google/ads/googleads/v1/common/url_col   |	    5160  Stored     5160   0% 01-01-1980 00:00 035c14a5  google/ads/googleads/v1/common/url_col
   48561  Defl:N     4948  90% 00-00-1980 00:00 90080b36  google/ads/googleads/v1/common/user_li   |	   47031  Stored    47031   0% 01-01-1980 00:00 c9c69202  google/ads/googleads/v1/common/user_li
    5872  Defl:N     1398  76% 00-00-1980 00:00 0be72097  google/ads/googleads/v1/common/value_p   |	    5685  Stored     5685   0% 01-01-1980 00:00 8609eecf  google/ads/googleads/v1/common/value_p
```

This turns off compression for files added to archives. After this, we get:

```
$ zipdiff gen/goprotoc/python/google/ads/googleads/v1/common/common.zip gen/protoc/python/google/ads/googleads/v1/common/common.zip
  705259           705259   0%                            27 files				   |	  673014           673014   0%                            27 files
--------          -------  ---                            -------					--------          -------  ---                            -------
 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name						 Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
--------  ------  ------- ---- ---------- ----- --------  ----						--------  ------  ------- ---- ---------- ----- --------  ----
    8674  Stored     8674   0% 00-00-1980 00:00 691f9e61  google/ads/googleads/v1/common/ad_asse   |	    8501  Stored     8501   0% 01-01-1980 00:00 dd46fa32  google/ads/googleads/v1/common/ad_asse
  104566  Stored   104566   0% 00-00-1980 00:00 63a1ab6f  google/ads/googleads/v1/common/ad_type   |	   99538  Stored    99538   0% 01-01-1980 00:00 47de1748  google/ads/googleads/v1/common/ad_type
   12439  Stored    12439   0% 00-00-1980 00:00 a9c7ead8  google/ads/googleads/v1/common/asset_t   |	   12082  Stored    12082   0% 01-01-1980 00:00 f3317fb6  google/ads/googleads/v1/common/asset_t
   33791  Stored    33791   0% 00-00-1980 00:00 36da3a17  google/ads/googleads/v1/common/bidding   |	   32290  Stored    32290   0% 01-01-1980 00:00 e15fc3d4  google/ads/googleads/v1/common/bidding
    5764  Stored     5764   0% 00-00-1980 00:00 35087162  google/ads/googleads/v1/common/click_l   |	    5583  Stored     5583   0% 01-01-1980 00:00 e37291fd  google/ads/googleads/v1/common/click_l
  124139  Stored   124139   0% 00-00-1980 00:00 7519e5e0  google/ads/googleads/v1/common/criteri   |	  120186  Stored   120186   0% 01-01-1980 00:00 c90d5746  google/ads/googleads/v1/common/criteri
   13801  Stored    13801   0% 00-00-1980 00:00 55e3eee0  google/ads/googleads/v1/common/criteri   |	   13309  Stored    13309   0% 01-01-1980 00:00 acc5ba46  google/ads/googleads/v1/common/criteri
    3948  Stored     3948   0% 00-00-1980 00:00 f1fe3921  google/ads/googleads/v1/common/custom_   |	    3891  Stored     3891   0% 01-01-1980 00:00 564e4ac4  google/ads/googleads/v1/common/custom_
    3847  Stored     3847   0% 00-00-1980 00:00 ae386051  google/ads/googleads/v1/common/dates_p   |	    3769  Stored     3769   0% 01-01-1980 00:00 63c6c91d  google/ads/googleads/v1/common/dates_p
    3614  Stored     3614   0% 00-00-1980 00:00 41516287  google/ads/googleads/v1/common/explore   |	    3582  Stored     3582   0% 01-01-1980 00:00 6935e778  google/ads/googleads/v1/common/explore
   65387  Stored    65387   0% 00-00-1980 00:00 b6447111  google/ads/googleads/v1/common/extensi   |	   62068  Stored    62068   0% 01-01-1980 00:00 aee20a8f  google/ads/googleads/v1/common/extensi
    3888  Stored     3888   0% 00-00-1980 00:00 9055aca4  google/ads/googleads/v1/common/feed_co   |	    3792  Stored     3792   0% 01-01-1980 00:00 5e776be2  google/ads/googleads/v1/common/feed_co
    4366  Stored     4366   0% 00-00-1980 00:00 5e9e5f70  google/ads/googleads/v1/common/final_a   |	    4310  Stored     4310   0% 01-01-1980 00:00 4e2bbb2a  google/ads/googleads/v1/common/final_a
    8523  Stored     8523   0% 00-00-1980 00:00 9610e854  google/ads/googleads/v1/common/frequen   |	    8326  Stored     8326   0% 01-01-1980 00:00 ecf16ca4  google/ads/googleads/v1/common/frequen
    4795  Stored     4795   0% 00-00-1980 00:00 117a4769  google/ads/googleads/v1/common/keyword   |	    4696  Stored     4696   0% 01-01-1980 00:00 834d85ca  google/ads/googleads/v1/common/keyword
   21461  Stored    21461   0% 00-00-1980 00:00 fb7e0551  google/ads/googleads/v1/common/matchin   |	   20680  Stored    20680   0% 01-01-1980 00:00 d3f0ba8f  google/ads/googleads/v1/common/matchin
   80071  Stored    80071   0% 00-00-1980 00:00 7fce3c4c  google/ads/googleads/v1/common/metrics   |	   72947  Stored    72947   0% 01-01-1980 00:00 18a80300  google/ads/googleads/v1/common/metrics
   39769  Stored    39769   0% 00-00-1980 00:00 92ca302c  google/ads/googleads/v1/common/policy_   |	   38304  Stored    38304   0% 01-01-1980 00:00 78c1722b  google/ads/googleads/v1/common/policy_
    3503  Stored     3503   0% 00-00-1980 00:00 4e74d2dc  google/ads/googleads/v1/common/real_ti   |	    3471  Stored     3471   0% 01-01-1980 00:00 5792ee1b  google/ads/googleads/v1/common/real_ti
   59412  Stored    59412   0% 00-00-1980 00:00 1664831d  google/ads/googleads/v1/common/segment   |	   55592  Stored    55592   0% 01-01-1980 00:00 6697a543  google/ads/googleads/v1/common/segment
   23746  Stored    23746   0% 00-00-1980 00:00 20ece356  google/ads/googleads/v1/common/simulat   |	   22648  Stored    22648   0% 01-01-1980 00:00 c2d38290  google/ads/googleads/v1/common/simulat
    5984  Stored     5984   0% 00-00-1980 00:00 b04a0828  google/ads/googleads/v1/common/tag_sni   |	    5834  Stored     5834   0% 01-01-1980 00:00 988ead38  google/ads/googleads/v1/common/tag_sni
    6034  Stored     6034   0% 00-00-1980 00:00 527ad26e  google/ads/googleads/v1/common/targeti   |	    5885  Stored     5885   0% 01-01-1980 00:00 00612e68  google/ads/googleads/v1/common/targeti
    3960  Stored     3960   0% 00-00-1980 00:00 0b2f2e2a  google/ads/googleads/v1/common/text_la   |	    3854  Stored     3854   0% 01-01-1980 00:00 22727024  google/ads/googleads/v1/common/text_la
    5344  Stored     5344   0% 00-00-1980 00:00 437652db  google/ads/googleads/v1/common/url_col   |	    5160  Stored     5160   0% 01-01-1980 00:00 035c14a5  google/ads/googleads/v1/common/url_col
   48561  Stored    48561   0% 00-00-1980 00:00 90080b36  google/ads/googleads/v1/common/user_li   |	   47031  Stored    47031   0% 01-01-1980 00:00 c9c69202  google/ads/googleads/v1/common/user_li
    5872  Stored     5872   0% 00-00-1980 00:00 0be72097  google/ads/googleads/v1/common/value_p   |	    5685  Stored     5685   0% 01-01-1980 00:00 8609eecf  google/ads/googleads/v1/common/value_p
```

The files still differ in size, but this is due to other issues such as https://github.com/protocolbuffers/protobuf/issues/6175