### PR TITLE
add support for newer ServiceDesc var, generated by newer protoc-gen-go-grpc

### DIFF
--- a/plugins/names_test.go
+++ b/plugins/names_test.go
@@ -285,6 +285,10 @@ func TestGoNameOfMethod(t *testing.T) {
 	// TODO
 }
 
+func TestGoNameOfExportedServiceDesc(t *testing.T) {
+	// TODO
+}
+
 func TestGoNameOfServiceDesc(t *testing.T) {
 	// TODO
 }


### PR DESCRIPTION
The service desc var was previously named `_<ServiceName>_serviceDesc`. But it is not exposed/exported, so the newer code generator names the var `<ServiceName>_ServiceDesc`.

This adds support to `GoNames` to provide the new symbol. Sadly, for backwards compatibility, I had to leave the old method in place with the same behavior (even though it no longer generates correct symbols unless you are using old grpc plugin). I tried to clarify the difference in Go doc comments.